### PR TITLE
Bug fix: writeUInt32Digital processes writes to ScaVals twice

### DIFF
--- a/configure/RELEASE.local
+++ b/configure/RELEASE.local
@@ -3,7 +3,7 @@
 # Read definitions of:
 #	EPICS_SITE_TOP
 #	BASE_MODULE_VERSION
-#	EPICS_MODULES 
+#	EPICS_MODULES
 # from one of the following options
 -include $(TOP)/../../RELEASE_SITE
 -include $(TOP)/RELEASE_SITE
@@ -26,7 +26,7 @@ YAMLLOADER_VERSION=R2.1.1
 # Define module paths using pattern
 # FOO = $(EPICS_MODULES)/foo/$(FOO_MODULE_VERSION)
 #  or
-# FOO = /Full/Path/To/Development/Version 
+# FOO = /Full/Path/To/Development/Version
 # ==========================================================
 ASYN=$(EPICS_MODULES)/asyn/$(ASYN_MODULE_VERSION)
 YAMLLOADER=$(EPICS_MODULES)/yamlLoader/$(YAMLLOADER_VERSION)

--- a/configure/RELEASE.local
+++ b/configure/RELEASE.local
@@ -20,7 +20,7 @@
 # could match a directory name.
 # ==========================================================
 ASYN_MODULE_VERSION=R4.32-1.0.0
-YAMLLOADER_VERSION=R2.1.1
+YAMLLOADER_VERSION=R2.1.0
 
 # ==========================================================
 # Define module paths using pattern

--- a/ycpswasynApp/src/drvYCPSWASYN.cpp
+++ b/ycpswasynApp/src/drvYCPSWASYN.cpp
@@ -2207,7 +2207,7 @@ asynStatus YCPSWASYN::writeUInt32Digital(asynUser *pasynUser, epicsUInt32 value,
                 val |= value;
                 rw[function]->setVal((uint32_t*)&val, 1);
             }
-            if(addr == DEV_CMD)
+            else if(addr == DEV_CMD)
             {
                 cmd[function]->execute();
             }


### PR DESCRIPTION
Add missing else statement. See details here:
https://jira.slac.stanford.edu/browse/ESLCOMMON-278

Also, revert the version of yamlLoader, as version R2.1.1 doesn't exist.