### PR TITLE
Set initial values for parameters related to save/load configs

### DIFF
--- a/ycpswasynApp/src/drvYCPSWASYN.cpp
+++ b/ycpswasynApp/src/drvYCPSWASYN.cpp
@@ -2031,21 +2031,25 @@ asynStatus YCPSWASYN::writeOctet (asynUser *pasynUser, const char *value, size_t
                 {
                     saveConfigFileName = std::string(value);
                     *nActual = maxChars;
+                    status = (asynStatus)setStringParam(DEV_CONFIG, saveConfigFileValue_, value);
                 }
                 else if (function == loadConfigFileValue_)
                 {
                     loadConfigFileName = std::string(value);
                     *nActual = maxChars;
+                    status = (asynStatus)setStringParam(DEV_CONFIG, loadConfigFileValue_, value);
                 }
                 else if (function == loadConfigRootValue_)
                 {
                     loadConfigRootPath = std::string(value);
                     *nActual = maxChars;
+                    status = (asynStatus)setStringParam(DEV_CONFIG, loadConfigRootValue_, value);
                 }
                 else if (function == saveConfigRootValue_)
                 {
                     saveConfigRootPath = std::string(value);
                     *nActual = maxChars;
+                    status = (asynStatus)setStringParam(DEV_CONFIG, saveConfigRootValue_, value);
                 }
                 else
                     status = writeOctet (pasynUser, value, maxChars, nActual);

--- a/ycpswasynApp/src/drvYCPSWASYN.cpp
+++ b/ycpswasynApp/src/drvYCPSWASYN.cpp
@@ -124,6 +124,16 @@ YCPSWASYN::YCPSWASYN(const char *portName, Path p, const char *recordPrefix, int
     createParam(DEV_CONFIG, saveConfigStatusString, asynParamUInt32Digital, &saveConfigStatusValue_);
     createParam(DEV_CONFIG, loadConfigRootString,   asynParamOctet,         &loadConfigRootValue_);
     createParam(DEV_CONFIG, saveConfigRootString,   asynParamOctet,         &saveConfigRootValue_);
+
+    // Set initial values for these parameters in the parameter library
+    setIntegerParam(DEV_CONFIG,     loadConfigValue_,     0);
+    setIntegerParam(DEV_CONFIG,     saveConfigValue_,     0);
+    setStringParam(DEV_CONFIG,      loadConfigFileValue_, "");
+    setStringParam(DEV_CONFIG,      saveConfigFileValue_, "");
+    setStringParam(DEV_CONFIG,      loadConfigRootValue_, "");
+    setStringParam(DEV_CONFIG,      saveConfigRootValue_, "");
+    setUIntDigitalParam(DEV_CONFIG, saveConfigStatusValue_, CONFIG_STAT_IDLE, PROCESS_CONFIG_MASK);
+    setUIntDigitalParam(DEV_CONFIG, loadConfigStatusValue_, CONFIG_STAT_IDLE, PROCESS_CONFIG_MASK);
 }
 
 

--- a/ycpswasynApp/src/drvYCPSWASYN.cpp
+++ b/ycpswasynApp/src/drvYCPSWASYN.cpp
@@ -2031,25 +2031,25 @@ asynStatus YCPSWASYN::writeOctet (asynUser *pasynUser, const char *value, size_t
                 {
                     saveConfigFileName = std::string(value);
                     *nActual = maxChars;
-                    status = (asynStatus)setStringParam(DEV_CONFIG, saveConfigFileValue_, value);
+                    status = setStringParam(DEV_CONFIG, saveConfigFileValue_, value);
                 }
                 else if (function == loadConfigFileValue_)
                 {
                     loadConfigFileName = std::string(value);
                     *nActual = maxChars;
-                    status = (asynStatus)setStringParam(DEV_CONFIG, loadConfigFileValue_, value);
+                    status = setStringParam(DEV_CONFIG, loadConfigFileValue_, value);
                 }
                 else if (function == loadConfigRootValue_)
                 {
                     loadConfigRootPath = std::string(value);
                     *nActual = maxChars;
-                    status = (asynStatus)setStringParam(DEV_CONFIG, loadConfigRootValue_, value);
+                    status = setStringParam(DEV_CONFIG, loadConfigRootValue_, value);
                 }
                 else if (function == saveConfigRootValue_)
                 {
                     saveConfigRootPath = std::string(value);
                     *nActual = maxChars;
-                    status = (asynStatus)setStringParam(DEV_CONFIG, saveConfigRootValue_, value);
+                    status = setStringParam(DEV_CONFIG, saveConfigRootValue_, value);
                 }
                 else
                     status = writeOctet (pasynUser, value, maxChars, nActual);


### PR DESCRIPTION
This will remove errors messages during IOC boot when these PV are read and the parameter library doesn't have any initial value.
This PR also fixes a bug, where the values passed to the `writeOctect` method were not written to the parameter library.

https://jira.slac.stanford.edu/browse/ESLCOMMON-281