### PR TITLE
Examples for launching cpswTreeGUI.

### DIFF
--- a/README.launchTreeGUI.md
+++ b/README.launchTreeGUI.md
@@ -1,0 +1,28 @@
+# How to launch the cpswTreeGUI
+
+## Overview
+
+The cpswTreeGUI is a Qt application for inspecting and modifying firmware registers at runtime. The register heirarchy is defined in YAML.
+
+The TreeGUI is normally launched with a set of command line parameters to connect to the correct FPGA. These parameters are static to an IOC so they can be stored in an EPICS database and looked up when, say, a button on another screen is clicked. This way you can simply pass macros to a display so that it can look up the values in PVs at runtime.
+
+## Background
+
+You should be familiar with CPSW and how hierarchies are defined in YAML.
+
+Go to the CPSW and YAML go to the official [confluence page about CPSW](https://confluence.slac.stanford.edu/display/ppareg/CPSW%3A+HowTo+User+Guide), or take a look at the README files in the CPSW framework package area.
+
+
+## Requirements
+
+You should include the database located in <TOP>/ycpswasyn/Db/treeGui.db in your application. In your <TOP>/<Name>App/Db/Makefile add
+
+`DB_INSTALLS += $(YCPSWASYN)/db/treeGui.db`
+
+Additionally, the TreeGUI requires a 'backdoor' YAML tarball if you want to run it alongside your IOC. After getting the backdoor tarball from the system firmware engineer, place it in <TOP>/firmware
+
+### Example and Display
+
+A database example is given as a reference. It it located in `<TOP>/ycpswasyn/Db/treeGui.db`
+
+An example PyDM display that you can use with this is located in `$TOOLS/pydm/display/util/`. There are a pair of files, `fpga_config.ui` and `fpga_config.py`

--- a/ycpswasynApp/Db/treeGui.db
+++ b/ycpswasynApp/Db/treeGui.db
@@ -1,0 +1,24 @@
+#
+# treeGui.db
+# Meta information about the IOC
+# used for building command line arguments for cpswTreeGUI
+#
+
+record(stringin, "SIOC:$(AREA):$(IOC_UNIT):CPU") {
+    field(DESC, "IOC Host CPU") 
+    info(autosaveFields, "VAL")
+}
+
+record(stringin, "SIOC:$(AREA):$(IOC_UNIT):SHM") {
+    field(DESC, "IOC Host Shelf Manager") 
+    info(autosaveFields, "VAL")
+}
+
+record(longin, "SIOC:$(AREA):$(IOC_UNIT):ATCA_SLOT") {
+    info(autosaveFields, "VAL")
+}
+
+record(longin, "SIOC:$(AREA):$(IOC_UNIT):ATCA_CRATE") {
+    info(autosaveFields, "VAL")
+}
+


### PR DESCRIPTION
the cpswTreeGUI is a useful tool for system engineers. To launch it requires quite a few command line arguments to properly connect to the firmware. This PR adds a README and a reference EPICS database to provide support in the IOC for storing the necessary command line arguments . This would allow one to, for example, launch the GUI from a PyDM display using existing macros.